### PR TITLE
feat: explain the model with feature importances and SHAP (#9)

### DIFF
--- a/01_notebooks/prediction.ipynb
+++ b/01_notebooks/prediction.ipynb
@@ -572,13 +572,21 @@
    "metadata": {},
    "source": [
     "The waterfall plot explains one single loan - the one the model scores as the\n",
-    "riskiest in the sample. It starts at the average prediction over the sample\n",
-    "(`E[f(x)]`) and adds each feature's contribution until it reaches the\n",
-    "prediction for this loan (`f(x)`).\n",
+    "riskiest in the sample. It starts at the model's base value (`E[f(x)]`) and adds\n",
+    "each feature's contribution until it reaches the prediction for this loan\n",
+    "(`f(x)`).\n",
+    "\n",
+    "`E[f(x)]` is not the average prediction over this sample. `TreeExplainer`\n",
+    "derives it from the training-data weights stored in the trees, and those weights\n",
+    "carry the `class_weight=\"balanced\"` that `src/train.py` sets - so the baseline\n",
+    "sits near 0.5 rather than near the actual default rate of the portfolio. Every\n",
+    "contribution in the plot is measured against that balanced starting point, which\n",
+    "is the same caveat the calibration section makes: this model ranks, it does not\n",
+    "hand out PDs.\n",
     "\n",
     "This is the format an adverse-action notice or a credit officer's override\n",
     "needs: not \"the model said 0.87\", but which characteristics of this specific\n",
-    "application drove it there and by how much."
+    "application drove it there and by how much.\n"
    ]
   },
   {

--- a/01_notebooks/prediction.ipynb
+++ b/01_notebooks/prediction.ipynb
@@ -34,7 +34,9 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "import seaborn as sns\n",
+    "import shap\n",
     "from sklearn.calibration import CalibrationDisplay\n",
     "\n",
     "# The notebook lives in 01_notebooks/, the src package in the project root.\n",
@@ -442,6 +444,141 @@
     ")\n",
     "plt.title('Calibration Curve (Reliability Diagram)')\n",
     "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Model Interpretability\n",
+    "\n",
+    "A credit decision has to be explainable: the applicant is entitled to a reason\n",
+    "for a rejection, and model validation has to be able to check that the model\n",
+    "keys on risk drivers that make economic sense rather than on an artefact of the\n",
+    "data. A random forest gives no such explanation by itself, so two views are\n",
+    "added here.\n",
+    "\n",
+    "`feature_importances_` answers \"which features does the forest use\", SHAP\n",
+    "answers \"in which direction, and by how much, does each feature move *this*\n",
+    "prediction\". The second question is the one a credit risk function actually\n",
+    "asks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "importances = pd.Series(model.feature_importances_, index=X_train.columns)\n",
+    "\n",
+    "plt.figure(figsize=(10, 7))\n",
+    "importances.nlargest(15).sort_values().plot.barh()\n",
+    "plt.title('Top 15 Features by Random Forest Importance')\n",
+    "plt.xlabel('Mean decrease in impurity')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The bar chart above ranks features by mean decrease in impurity, which has two\n",
+    "well-known limits: it says nothing about the *direction* of an effect, and it\n",
+    "systematically favours continuous and high-cardinality features over binary\n",
+    "ones, because those offer the trees more places to split. A one-hot column can\n",
+    "therefore look unimportant here while still mattering for individual decisions.\n",
+    "\n",
+    "SHAP values fix both problems. They attribute each single prediction to its\n",
+    "features, so they carry a sign, and they are comparable across feature types.\n",
+    "Following the issue, they are computed on a random sample rather than the full\n",
+    "test set - `TreeExplainer` on a forest with this many rows and columns is slow,\n",
+    "and a few thousand rows are enough for a stable summary plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_shap = X_test.sample(min(3000, len(X_test)), random_state=42)\n",
+    "\n",
+    "# Index 1 of the last axis selects the contributions to the default class.\n",
+    "shap_values = shap.TreeExplainer(model)(X_shap)[:, :, 1]\n",
+    "\n",
+    "shap.plots.beeswarm(shap_values, max_display=15, show=False)\n",
+    "plt.title('SHAP Summary: Impact on Predicted Default Probability')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading the summary plot\n",
+    "\n",
+    "Each dot is one loan. Its position on the x-axis is that feature's contribution\n",
+    "to that loan's default probability - right of zero pushes the prediction\n",
+    "towards default, left of zero away from it. The colour is the feature value, so\n",
+    "\"red on the right\" means high values of the feature increase the predicted risk.\n",
+    "\n",
+    "One caveat specific to this notebook: the features were standardized before\n",
+    "training, so the colour scale refers to the scaled values. Standardization is\n",
+    "monotonic, so red still means a high value in the original units - but the\n",
+    "numbers on the colour bar are not dollars, percent or years.\n",
+    "\n",
+    "Whether the pattern makes economic sense is the actual test, and three features\n",
+    "are worth checking explicitly:\n",
+    "\n",
+    "- **`int_rate`** is expected to be the strongest single driver, with high rates\n",
+    "  pushing the prediction towards default. That is not leakage - the rate is set\n",
+    "  at origination - but it deserves a caveat rather than applause: LendingClub\n",
+    "  derives the rate from its own internal credit grade, and `grade`/`sub_grade`\n",
+    "  were dropped from the feature set as identifiers. A model dominated by\n",
+    "  `int_rate` is therefore mostly reproducing the platform's own underwriting\n",
+    "  decision instead of assessing the borrower independently. A bank building a\n",
+    "  scorecard would look at how much discriminatory power survives without it.\n",
+    "- **`dti`** (debt-to-income) is the most defensible driver economically: it\n",
+    "  measures how much of the borrower's income is already committed to debt\n",
+    "  service, and a borrower with little headroom has less capacity to absorb an\n",
+    "  income shock. Higher `dti` should push towards default; if it did not, the\n",
+    "  model would be suspect, not the theory.\n",
+    "- **`term`** should show 60-month loans as riskier than 36-month ones, for two\n",
+    "  reasons that compound: the loan is exposed to adverse events for longer, and\n",
+    "  borrowers who choose the longer term to get a lower instalment tend to be the\n",
+    "  more stretched ones to begin with. This is a good example of a feature whose\n",
+    "  effect is part duration and part self-selection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "riskiest = int(model.predict_proba(X_shap)[:, 1].argmax())\n",
+    "\n",
+    "shap.plots.waterfall(shap_values[riskiest], max_display=12, show=False)\n",
+    "plt.title('Single Case: Why This Loan Is Scored As High Risk')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The waterfall plot explains one single loan - the one the model scores as the\n",
+    "riskiest in the sample. It starts at the average prediction over the sample\n",
+    "(`E[f(x)]`) and adds each feature's contribution until it reaches the\n",
+    "prediction for this loan (`f(x)`).\n",
+    "\n",
+    "This is the format an adverse-action notice or a credit officer's override\n",
+    "needs: not \"the model said 0.87\", but which characteristics of this specific\n",
+    "application drove it there and by how much."
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 seaborn
 joblib
 scipy
+shap

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
 from scipy.stats import ks_2samp
 from sklearn.base import ClassifierMixin
@@ -13,7 +12,7 @@ TARGET_NAMES = ["Fully Paid (0)", "Charged Off (1)"]
 
 
 def evaluate_model(
-    model: ClassifierMixin, x_test: np.ndarray, y_test: pd.Series
+    model: ClassifierMixin, x_test: pd.DataFrame, y_test: pd.Series
 ) -> dict[str, object]:
     """Score a fitted model on the test set.
 

--- a/src/train.py
+++ b/src/train.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import joblib
-import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
@@ -17,11 +16,16 @@ def split_and_scale(
     y: pd.Series,
     test_size: float = 0.3,
     random_state: int = 42,
-) -> tuple[np.ndarray, np.ndarray, pd.Series, pd.Series, StandardScaler]:
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series, StandardScaler]:
     """Split the data stratified by the target and standardize the features.
 
     The scaler is fitted on the training set only, so no information from the
     test set enters the training data.
+
+    ``set_output(transform="pandas")`` keeps the scaled features as DataFrames.
+    Plain ``StandardScaler`` output would be a numpy array, which drops the
+    column names and leaves feature importances and SHAP plots labelled with
+    positional indices instead of feature names.
 
     :param x: Feature matrix.
     :param y: Binary target.
@@ -32,7 +36,7 @@ def split_and_scale(
     x_train, x_test, y_train, y_test = train_test_split(
         x, y, test_size=test_size, random_state=random_state, stratify=y
     )
-    scaler = StandardScaler()
+    scaler = StandardScaler().set_output(transform="pandas")
     return (
         scaler.fit_transform(x_train),
         scaler.transform(x_test),
@@ -43,7 +47,7 @@ def split_and_scale(
 
 
 def train_random_forest(
-    x_train: np.ndarray, y_train: pd.Series, random_state: int = 42
+    x_train: pd.DataFrame, y_train: pd.Series, random_state: int = 42
 ) -> RandomForestClassifier:
     """Train a random forest on the scaled training data.
 


### PR DESCRIPTION
## Summary

The notebook trained a random forest and reported metrics for it, but said nothing about *which* features drive the prediction. In a credit risk context that is the part a validator and a rejected applicant both ask about. This PR adds a "6. Model Interpretability" section with an impurity-importance chart, a SHAP summary plot and a single-case waterfall plot, each with a short interpretation.

## Type of change
- [ ] Bugfix
- [x] New feature / analysis
- [ ] Refactoring (keine Verhaltensänderung)
- [x] Documentation
- [ ] Model/metrics change

## Related issue

Issue #9. `Closes #9` does not fire here because this PR targets the integration branch, not the default branch — the reviewer closes the issue manually after the merge.

## Changes

- `src/train.py`: `split_and_scale` sets `set_output(transform="pandas")` on the scaler, so the scaled features stay DataFrames. **This is the open finding carried over from the PR #17 review**, which recorded #9 as its natural home: plain `StandardScaler` returns a numpy array, the column names are lost, and both new plots would be labelled with positional indices instead of feature names. Type hints on `split_and_scale`/`train_random_forest` updated accordingly; the `numpy` import became unused and was removed.
- `src/evaluate.py`: `x_test` type hint corrected to `pd.DataFrame` to match what `split_and_scale` now returns (and its `numpy` import, only used for that hint, removed). No behaviour change.
- `01_notebooks/prediction.ipynb`: new section with three code cells and four markdown cells; `pandas` and `shap` added to the import cell.
- `requirements.txt`: `shap` added.

Deliberately kept out of `src/`: the importance chart is a two-line pandas expression (`pd.Series(...).nlargest(15).sort_values().plot.barh()`) and the SHAP plots are direct `shap.plots.*` calls. Wrapping either in a project function would be the speculative abstraction `CLAUDE_CODING_RULES.md` rules out — the same reasoning the #8 review applied to `CalibrationDisplay`.

Step 5 of the issue (the single-case explanation) is marked optional. It is included: it is four lines, and it is the format an adverse-action notice actually needs, which is the motivation the issue's own context section gives.

## Model/Data-Leakage-Check

- [x] Beeinflusst dieser PR Trainingsdaten, Features oder das Modell? **No.** The feature set, the split, the seed and the model are unchanged. `set_output(transform="pandas")` changes the container of the scaled data, not its values — `StandardScaler` computes the same numbers either way.
- [ ] Falls ja: alte vs. neue Metriken — not applicable, the model is untouched.
- [x] Keine neuen Features verwendet, die erst nach Kreditvergabe/Ausfall bekannt sind — no feature changes.
- [x] Ein auffällig hoher/niedriger Metrikwert wurde erklärt, nicht nur berichtet — no metric values are quoted; see below.

## How to test / Verification

The raw CSV is not in the repo, so a *copy* of the notebook was executed with `nbclient` against a synthetic LendingClub-shaped CSV (4000 rows, every column the notebook and `src/` touch):

- all 22 code cells run top to bottom, `execution_count` 1–22, zero errors,
- each of the three new cells emits exactly one PNG,
- the point of the scaler change was verified directly: `model.feature_importances_` is indexed by column name and `TreeExplainer(...)` returns `feature_names` that are all strings, not positional indices,
- the three features discussed in the markdown (`int_rate`, `dti`, `term`) were confirmed to survive the cleaning chain and be present in the final feature matrix.

`black --check src/` and `ruff check src/` pass. The executed copy and the synthetic CSV were **not** committed; the notebook is committed unexecuted, consistent with the decision taken in #5.

**No metric or importance values are quoted anywhere in the notebook.** On synthetic data the importance ranking is noise, so the interpretation cells are phrased as expectations to check against a real run (the local run still outstanding from #2/#5), in the same style the #2 review settled on for the 0.65–0.75 AUC range.

## Checklist
- [x] Notebook läuft sauber von oben nach unten durch (against synthetic data, see above; the real-data run is still the open local task from #5)
- [ ] Tests laufen durch (`pytest tests/`) — `tests/` does not exist yet, see issue #6
- [x] README ggf. aktualisiert — not affected; README metrics stay untouched until the notebook has run on real data (issue #3)
- [x] Keine Secrets/Zugangsdaten committet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeH9skzs1ScZsnrZy1wn8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeH9skzs1ScZsnrZy1wn8n)_