### PR TITLE
docs: align the README with the actual repository (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,151 @@
 # Credit Risk Modelling
 
-This project demonstrates a full machine learning workflow for **predicting loan defaults** using the historical LendingClub dataset (2007–2018Q4). The goal is to identify loans that are at high risk of default ("Charged Off") in order to support risk-aware lending and investment decisions.
+A probability-of-default (PD) model on the historical LendingClub dataset
+(2007-2018Q4). The task is to estimate, at the moment of application, how likely
+a loan is to end as "Charged Off" — the question a credit risk function answers
+before the money leaves the bank.
 
-## Dataset  
-The dataset consists of over **2.2 million loan records with 151 features**, including borrower information, loan characteristics, and repayment outcomes.  
-- **Source:** LendingClub accepted loan data (2007–2018Q4)  
-- **Target variable:** loan status, simplified to a binary outcome:  
-  - `0` = Fully Paid  
-  - `1` = Charged Off  
+## Dataset
 
-## Workflow  
+LendingClub accepted loan data, ~2.2 million records with 151 columns covering
+borrower attributes, loan characteristics and repayment outcomes.
 
-### 1. Exploratory Data Analysis (EDA)  
-- Distribution analysis (loan amounts, issuance per year, grades)  
-- Correlation heatmaps of numerical features  
+- **Source:** [LendingClub accepted loans (2007-2018Q4) on Kaggle](https://www.kaggle.com/datasets/wordsforthewise/lending-club)
+- **Target:** `loan_status`, reduced to a binary outcome — `0` = Fully Paid,
+  `1` = Charged Off. Loans that are still running are excluded: their outcome is
+  not yet known, and labelling them as non-defaults would be wrong.
+- **Window:** the analysis is restricted to loans issued 2015-2018. LendingClub's
+  volume grew by orders of magnitude over the full history and its lending
+  standards changed with it, so a recent, homogeneous window is closer to the
+  population a scorecard would actually be applied to.
 
-### 2. Data Cleaning & Preprocessing  
-- Filtered to completed loans only (`Fully Paid`, `Charged Off`)  
-- Removed irrelevant identifiers, text-based, and date-leakage features  
-- Dropped columns with >40% missing values and rows with remaining nulls  
-- Reduced dataset to ~418k clean samples and 95 features  
+The raw CSV is ~1.6 GB and is **not** part of this repository (see
+`.gitignore`); it has to be downloaded separately, see "How to run".
 
-### 3. Feature Engineering  
-- Converted `term` and `emp_length` into numerical values  
-- One-hot encoded categorical variables  
-- Standardized numerical features  
-- Final dataset size: ~418k rows × 156 features  
+## How to run
 
-### 4. Model Training  
-- Stratified train-test split (70/30)  
-- Applied **Random Forest Classifier** with `class_weight="balanced"`  
-- Trained on ~293k samples, tested on ~125k  
+**1. Get the data.** Download the dataset from the Kaggle link above and place
+`accepted_2007_to_2018Q4.csv` in `02_data/raw/`. Nothing else needs to be put
+there — the notebook does all cleaning in memory.
 
-### 5. Model Evaluation  
-- **ROC AUC Score: 0.9999**  
-- High precision and recall for both classes  
-- Strong performance in identifying defaults, the main risk factor for investors  
+**2. Set up the environment.** Python 3.11 is what this was developed against;
+3.10+ should work. `src/train.py` uses `StandardScaler.set_output`, which needs
+scikit-learn 1.2 or newer.
 
-## Key Findings  
-- The Random Forest model demonstrates excellent discriminatory power between defaulted and fully paid loans.  
-- High recall for the "Charged Off" class suggests the model is well-suited to flagging risky loans.  
-- The workflow provides a robust baseline for credit risk prediction and can be extended with more advanced models (e.g., XGBoost, deep learning).  
+```bash
+python -m venv venv
+source venv/bin/activate        # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
 
+**3. Run the notebook**, top to bottom ("Restart & Run All"):
 
-## Folder Structure
+```bash
+jupyter notebook 01_notebooks/prediction.ipynb
+```
+
+Non-interactively, writing the outputs back into the notebook:
+
+```bash
+jupyter nbconvert --to notebook --execute --inplace 01_notebooks/prediction.ipynb
+```
+
+A full run takes a few minutes and a fair amount of memory, mostly for loading
+the raw CSV. For a quick pass, the loading cell documents how to read only a
+sample via `nrows`. The run writes one artefact, the fitted model, to
+`04_models/random_forest.joblib` (untracked).
+
+The notebook imports the pipeline from `src/`, so it has to be run from within
+the repository — the import cell puts the project root on `sys.path` relative to
+`01_notebooks/`.
+
+## Repository layout
 
 ```
-Folder Structure/
+credit-risk-modelling/
 │
-├── .gitignore
 ├── README.md
 ├── requirements.txt
+├── .gitignore
 │
 ├── 01_notebooks/
-│   └── 1.0-eda-and-prototyping.ipynb
+│   └── prediction.ipynb          # the analysis: EDA, cleaning, model, evaluation
+│
+├── src/                          # importable pipeline used by the notebook
+│   ├── __init__.py
+│   ├── data_processing.py        # loading, target, leakage and NaN handling
+│   ├── features.py               # term/emp_length conversion, one-hot encoding
+│   ├── train.py                  # split, scaling, random forest, persistence
+│   └── evaluate.py               # ROC AUC, Gini, KS, classification report
 │
 ├── 02_data/
-│   ├── raw/
-│   │   └── lending_file_2015_2016.csv
-│   └── processed/
-│       └── cleaned_lending_data.csv
+│   ├── raw/                      # place accepted_2007_to_2018Q4.csv here (untracked)
+│   └── processed/                # unused; the pipeline keeps intermediates in memory
 │
-├── src/
-│   ├── __init__.py
-│   ├── data_processing.py
-│   ├── features.py
-│   ├── train.py
-│   └── evaluate.py
-│
-└── 04_models/
-    └── random_forest.joblib
+└── 04_models/                    # random_forest.joblib is written here (untracked)
 ```
+
+`docs/` and the `CLAUDE*.md` files at the repository root are working material
+for the ongoing rework of this repository, not part of the analysis.
+
+## Workflow
+
+The notebook follows the pipeline in `src/` section by section.
+
+**1. Load data** — read the raw CSV.
+
+**2. Exploratory analysis** — loan amount distribution, issuance volume per year
+(which motivates the 2015-2018 window), correlation structure of the numeric
+features.
+
+**3. Cleaning and preprocessing** — keep only completed loans, drop columns with
+more than 40% missing values, remove identifiers, free text and date columns,
+then drop the rows that still carry NaNs.
+
+This step also removes every **post-outcome column** — `total_pymnt`,
+`recoveries`, `last_fico_range_*` and the rest of the fields that are only
+filled once the loan has been repaid or has defaulted. They are the reason the
+first version of this project reported an ROC AUC of 0.9999: they leak the
+target into the features. The concrete lists live in `src/data_processing.py`.
+
+**4. Feature engineering** — `term` and `emp_length` converted to numbers, the
+remaining categorical columns one-hot encoded.
+
+**5. Training and evaluation** — stratified 70/30 split, features standardized
+with a scaler fitted on the training set only, `RandomForestClassifier` with
+`class_weight="balanced"`. Evaluation reports ROC AUC, Gini and the KS statistic
+for discrimination, plus a reliability diagram for calibration.
+
+**6. Interpretability** — impurity-based feature importances, a SHAP summary
+plot showing the direction and size of each feature's effect, and a waterfall
+plot explaining one single high-risk loan in the form an adverse-action notice
+would need.
+
+## Results
+
+**The corrected model has not yet been run on the full dataset, so no metrics
+are quoted here.**
+
+Earlier versions of this README reported an ROC AUC of **0.9999**. That number
+was an artefact of the data leakage described in step 3, not evidence of
+predictive power — the model was reading columns that only exist because the
+outcome was already known. It has been removed rather than restated.
+
+What the corrected model should produce, once the notebook has been run against
+the full dataset, is an ROC AUC in the region of **0.65-0.75** — a Gini of
+roughly 0.30-0.50 in the form a scorecard validation would report it. That is
+what a realistic PD model on LendingClub data achieves and what can be defended
+in a credit risk context. This section will be filled in with the measured
+values from that run.
+
+Two things are worth stating up front about how those numbers should be read:
+
+- **Recall on the "Charged Off" class** is the business-relevant quantity — it
+  says how many of the loans that actually defaulted the model flags. Precision
+  and recall trade off against each other, so the decision threshold follows
+  from the cost of a missed default versus the cost of turning away a good
+  customer; the model does not choose it.
+- **Discrimination is not calibration.** With `class_weight="balanced"` the
+  predicted probabilities are deliberately shifted and cannot be used as PDs in
+  an expected-loss calculation without recalibration. That is acceptable for a
+  ranking model, but it has to be said rather than assumed.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ credit-risk-modelling/
 └── 04_models/                    # random_forest.joblib is written here (untracked)
 ```
 
-`docs/` and the `CLAUDE*.md` files at the repository root are working material
-for the ongoing rework of this repository, not part of the analysis.
+`docs/`, `HANDOVER.md` and the `CLAUDE*.md` files at the repository root are
+working material for the ongoing rework of this repository, not part of the
+analysis.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

The README described a repository that does not exist. Its folder structure named four files that are not in the repo, and there was no instruction for obtaining the raw data or running anything — which is the first thing an external reader (recruiter, interviewer) needs. This rewrites it against the repository as it stands after issues #2, #4, #5, #8 and #9, and removes the ROC AUC of 0.9999 rather than restating it.

## Type of change
- [ ] Bugfix
- [ ] New feature / analysis
- [ ] Refactoring (keine Verhaltensänderung)
- [x] Documentation
- [ ] Model/metrics change

## Related issue

Issue #3. `Closes #3` does not fire here because this PR targets the integration branch, not the default branch — the reviewer closes the issue manually after the merge.

## Changes

`README.md` only; no code is touched.

- **Folder structure** now lists what is actually there. The four phantom paths are gone: `01_notebooks/1.0-eda-and-prototyping.ipynb` (the notebook is `prediction.ipynb`), `02_data/raw/lending_file_2015_2016.csv` and `02_data/processed/cleaned_lending_data.csv` (both directories hold only a `.gitkeep`; nothing in the pipeline writes a processed file), and a tracked model artefact in `04_models/`. `04_models/random_forest.joblib` is still named, but as what it is — written by the run and untracked via `.gitignore`. Each `src/` module gets a one-line description of what it holds.
- **"How to run" added**, which the issue asked for and the README had nothing of: the Kaggle link and the exact filename and directory the raw CSV goes into, venv plus `pip install -r requirements.txt`, both the interactive and the `nbconvert` command, the note that the notebook must run from inside the repository because the import cell resolves `src/` relative to `01_notebooks/`, and the `nrows` shortcut for a quick pass.
- **Dataset section** states the 2015-2018 window and why it exists, which the old README never mentioned although the pipeline applies it.
- **Workflow section** rewritten to follow the notebook's six sections, including the leakage removal in step 3 and the metrics (Gini/KS/calibration) and interpretability sections added by #8 and #9.
- **Results section** replaces the old metrics block — see below.

## Model/Data-Leakage-Check

- [x] Beeinflusst dieser PR Trainingsdaten, Features oder das Modell? **No.** Documentation only.
- [x] Falls ja: alte vs. neue Metriken — the old value is *removed*, not replaced. See below.
- [x] Keine neuen Features verwendet, die erst nach Kreditvergabe/Ausfall bekannt sind — no feature changes.
- [x] Ein auffällig hoher/niedriger Metrikwert wurde erklärt, nicht nur berichtet — the 0.9999 is now explained as the leakage artefact it was, which is the whole point of the section.

### The one open decision: step 4 of the issue cannot be completed as written

Step 4 asks for the results section to be updated with the corrected AUC from issue #2. That number does not exist yet: the raw CSV is not in this repository and cannot be obtained in a cloud session, so the corrected notebook has never been run against the full dataset (the open local task carried in `HANDOVER.md` since #2 and #5).

Two options, and the conservative one was taken:

- Put the expected value in as if it had been measured — which would replace one fabricated metric with another, in a portfolio repo, on the exact issue whose subject is that the README claims things that are not true.
- Say plainly that the corrected run is outstanding, state the range the model is expected to land in (ROC AUC 0.65-0.75, Gini 0.30-0.50) as an expectation rather than a result, and explain why the 0.9999 was wrong.

The second, phrased in the style the #2 review settled on for the notebook's own closing cell. **Acceptance criterion 3 ("Metriken stimmen mit dem tatsächlichen Notebook-Output überein") therefore stays formally open** until that local run happens — at which point this section is a fill-in-the-numbers edit. Criteria 1 and 2 are met.

The section also carries two readings the numbers will need when they arrive: recall on the "Charged Off" class is the business-relevant quantity and the threshold follows from misclassification costs, and `class_weight="balanced"` means the predicted probabilities are not usable as PDs without recalibration.

## How to test / Verification

- Every path named in the README was checked against `git ls-files` and the filesystem: all 13 exist. The only two that do not are the raw CSV and the model artefact, both explicitly described as produced or downloaded rather than tracked, and both covered by `.gitignore`.
- Every factual claim was checked against the source rather than carried over: the 40% missing-value threshold (`rm_nas`, `threshold: float = 0.4`), the 70/30 split (`split_and_scale`, `test_size: float = 0.3`), `class_weight="balanced"` (`train_random_forest`), the 2015-2018 window (`filter_issue_years` defaults and the notebook's call), the post-outcome column names quoted as examples (all present in `POST_OUTCOME_COLS`), and that nothing writes to `02_data/processed/`.
- The scikit-learn floor named in the setup section (1.2, for `StandardScaler.set_output`) follows from the change made in #9. `requirements.txt` is unpinned by design — pinning is issue #7.

## Checklist
- [x] Notebook läuft sauber von oben nach unten durch — not affected; the notebook is untouched by this PR
- [ ] Tests laufen durch (`pytest tests/`) — `tests/` does not exist yet, see issue #6
- [x] README ggf. aktualisiert und weiterhin konsistent mit dem tatsächlichen Repo-Inhalt — this is that change
- [x] Keine Secrets/Zugangsdaten committet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CfiydUSp5Dqz84KnskcGW

---
_Generated by [Claude Code](https://claude.ai/code/session_015CfiydUSp5Dqz84KnskcGW)_