### PR TITLE
build: pin dependencies and add an MIT LICENSE (#7)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Felix Schramm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ The raw CSV is ~1.6 GB and is **not** part of this repository (see
 `accepted_2007_to_2018Q4.csv` in `02_data/raw/`. Nothing else needs to be put
 there — the notebook does all cleaning in memory.
 
-**2. Set up the environment.** Python 3.11 is what this was developed against;
-3.10+ should work. `requirements.txt` pins exact versions that were resolved and
-run together, so the install reproduces a known-good environment rather than
-whatever is current on PyPI. If you deviate from the pins: `src/train.py` uses
-`StandardScaler.set_output`, which needs scikit-learn 1.2 or newer.
+**2. Set up the environment.** Python 3.11 or newer is required — the pinned
+`pandas`, `numpy`, `scikit-learn`, `scipy`, `matplotlib` and `shap` releases all
+declare `requires-python >= 3.11`. `requirements.txt` pins exact versions that
+were resolved and run together, so the install reproduces a known-good
+environment rather than whatever is current on PyPI. If you deviate from the
+pins: `src/train.py` uses `StandardScaler.set_output`, which needs scikit-learn
+1.2 or newer.
 
 ```bash
 python -m venv venv
@@ -67,6 +69,7 @@ the repository — the import cell puts the project root on `sys.path` relative 
 credit-risk-modelling/
 │
 ├── README.md
+├── LICENSE
 ├── requirements.txt
 ├── .gitignore
 │

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ The raw CSV is ~1.6 GB and is **not** part of this repository (see
 there — the notebook does all cleaning in memory.
 
 **2. Set up the environment.** Python 3.11 is what this was developed against;
-3.10+ should work. `src/train.py` uses `StandardScaler.set_output`, which needs
-scikit-learn 1.2 or newer.
+3.10+ should work. `requirements.txt` pins exact versions that were resolved and
+run together, so the install reproduces a known-good environment rather than
+whatever is current on PyPI. If you deviate from the pins: `src/train.py` uses
+`StandardScaler.set_output`, which needs scikit-learn 1.2 or newer.
 
 ```bash
 python -m venv venv
@@ -150,3 +152,7 @@ Two things are worth stating up front about how those numbers should be read:
   predicted probabilities are deliberately shifted and cannot be used as PDs in
   an expected-loss calculation without recalibration. That is acceptable for a
   ranking model, but it has to be said rather than assumed.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,17 @@
-pandas
-numpy
-scikit-learn
-jupyter
-matplotlib
-seaborn
-joblib
-scipy
-shap
+# Pinned so that "Restart & Run All" keeps working. The versions below were
+# resolved together on Python 3.11 and the notebook was run end to end against
+# them; see issue #7.
+pandas==3.0.5
+numpy==2.4.6
+scikit-learn==1.9.0
+jupyter==1.1.1
+matplotlib==3.11.1
+seaborn==0.13.2
+joblib==1.6.0
+scipy==1.17.1
+shap==0.51.0
+
+# Development tools: tests (issue #6), formatting and linting (issue #13).
+pytest==9.1.1
+ruff==0.16.5
+black==26.5.1


### PR DESCRIPTION
## Summary

`requirements.txt` listed nine packages without a single version, so a "Restart & Run All" could break at any time through an upstream API change with nothing in the repo to explain it — and for a portfolio repo that a reviewer is meant to clone and run, that is the difference between a demo and an anecdote. This pins every entry and adds the `LICENSE` the repo was missing.

## Type of change
- [ ] Bugfix
- [ ] New feature / analysis
- [ ] Refactoring (keine Verhaltensänderung)
- [x] Documentation
- [x] Model/metrics change — no; build/packaging only, listed here because `requirements.txt` decides which library versions the model is trained under

## Related issue

Issue #7. `Closes #7` does not fire here because this PR targets the integration branch, not the default branch — the reviewer closes the issue manually after the merge.

## Changes

**`requirements.txt`** — every entry pinned, existing order kept:

| | |
|---|---|
| `pandas` | 3.0.5 |
| `numpy` | 2.4.6 |
| `scikit-learn` | 1.9.0 |
| `jupyter` | 1.1.1 |
| `matplotlib` | 3.11.1 |
| `seaborn` | 0.13.2 |
| `joblib` | 1.6.0 |
| `scipy` | 1.17.1 |
| `shap` | 0.51.0 |
| `pytest` | 9.1.1 |
| `ruff` | 0.16.5 |
| `black` | 26.5.1 |

A curated list of the twelve top-level packages, per step 1 of the issue, not a `pip freeze` dump — the resolved environment is 115 packages, and 103 of them are transitive noise that no reviewer should have to read past.

**`LICENSE`** — MIT, `Copyright (c) 2026 Felix Schramm`, verbatim OSI text so GitHub's licence detection picks it up and shows it in the repository header (acceptance criterion 3).

**`README.md`** — a three-line `## License` section, and the setup step now says the versions are pinned instead of naming a scikit-learn floor as the only version guidance. The floor itself is kept as a trailing clause, because it is the one non-obvious constraint for anyone who deviates from the pins.

## The three scope decisions

Step 2 of the issue asks for the packages that arrived with other issues. `shap` was already there from #9. Of the rest:

- **`pytest` and `ruff` — added.** Named explicitly in the issue; #6 and #13 need them.
- **`black` — added, not named in the issue.** `CLAUDE_CODING_RULES.md` mandates black formatting repo-wide, previous sessions have already run it against `src/`, and #13 ("Lint/Tests") will run it in CI next to `ruff`. It is a real, already-used dev dependency that was simply never listed; adding `ruff` while leaving its counterpart out would be the odd half-measure. Flagged here so it can be dropped in review if that reads as scope creep.
- **`optbinning` — left out.** The issue says "ggf.", and #10 has not chosen an approach yet. Pinning a package that nothing in the repo imports is exactly the speculative dependency `CLAUDE_CODING_RULES.md` warns against; #10 adds it when it needs it.

Step 3 (`pyproject.toml` via `uv`/`poetry`) was considered and declined, as the issue itself allows: a pinned `requirements.txt` is sufficient here, easier to review, and swapping the packaging system would be a much larger diff than the problem justifies.

## Model/Data-Leakage-Check

- [x] Beeinflusst dieser PR Trainingsdaten, Features oder das Modell? **No.** No code is touched; only the library versions it runs under.
- [x] Falls ja: alte vs. neue Metriken — not applicable, no metrics change.
- [x] Keine neuen Features verwendet, die erst nach Kreditvergabe/Ausfall bekannt sind — no feature changes.
- [x] Ein auffällig hoher/niedriger Metrikwert wurde erklärt — no metrics reported.

## How to test / Verification

Acceptance criterion 2 asks for a fresh virtual environment plus a notebook run, and that was executed rather than assumed — this is the one issue so far whose main criterion is verifiable without the real dataset, since it is the *versions* that are under test, not the numbers.

1. `python -m venv` from scratch, then `pip install -r requirements.txt` straight from the committed file: resolves and installs clean, and `pip list` confirms all twelve pins are exactly what the file asks for.
2. A copy of `01_notebooks/prediction.ipynb` executed top to bottom with `nbclient` inside that venv, against a synthetic LendingClub-shaped CSV (4000 rows, all 62 columns the notebook and `src/` touch, including every column in `POST_OUTCOME_COLS`): **all 22 code cells run, execution counts 1-22, zero errors**, and all seven plots render — importantly including the two SHAP plots and the calibration curve, which are the newest and most version-sensitive cells in the notebook.

This matters more than a routine smoke test, because the pins are not conservative: `pandas` 3.0 and `numpy` 2.x are both major releases against what this notebook was originally written for. The run confirms the pipeline is actually clean under them — Copy-on-Write included, which is the pandas 3 change most likely to have bitten the `.copy()`/assignment pattern in `src/data_processing.py`.

One thing the synthetic run surfaced that is **not** a defect in this PR and was not fixed here: `pd.read_csv` parses the literal string `n/a` as NaN, so the `value == "n/a"` branch in `convert_emp_length` can never fire on a real CSV — the missing values reach it as NaN and are caught by the `pd.isna` check on the line above, so behaviour is correct either way and the branch is merely dead. Left alone per "Surgical Changes"; noted in `HANDOVER.md`.

The unpinned-versus-pinned distinction has one honest limit worth stating: the pins are today's latest releases, verified together. They are not a claim that the notebook was ever run on the *real* dataset under them — that remains the outstanding local task carried since #2.

## Checklist
- [x] Notebook läuft sauber von oben nach unten durch — 22/22 cells in a fresh venv built from this `requirements.txt`, against synthetic data
- [ ] Tests laufen durch (`pytest tests/`) — `tests/` does not exist yet; that is issue #6, which this PR pins `pytest` for
- [x] README ggf. aktualisiert und weiterhin konsistent mit dem tatsächlichen Repo-Inhalt — licence section added, setup step updated, and `LICENSE` is a real file at the root
- [x] Keine Secrets/Zugangsdaten committet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8LgA31CcWnBSdMw71wbfv

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8LgA31CcWnBSdMw71wbfv)_