### PR TITLE
test: add a pytest suite for the src/ pipeline functions (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ The notebook imports the pipeline from `src/`, so it has to be run from within
 the repository — the import cell puts the project root on `sys.path` relative to
 `01_notebooks/`.
 
+**4. Run the tests** (optional, and independent of the dataset — they work on
+small synthetic frames):
+
+```bash
+pytest
+```
+
+`pytest.ini` points at `tests/` and puts the repository root on the import
+path, so the command works from the root without further arguments.
+
 ## Repository layout
 
 ```
@@ -71,6 +81,7 @@ credit-risk-modelling/
 ├── README.md
 ├── LICENSE
 ├── requirements.txt
+├── pytest.ini
 ├── .gitignore
 │
 ├── 01_notebooks/
@@ -82,6 +93,11 @@ credit-risk-modelling/
 │   ├── features.py               # term/emp_length conversion, one-hot encoding
 │   ├── train.py                  # split, scaling, random forest, persistence
 │   └── evaluate.py               # ROC AUC, Gini, KS, classification report
+│
+├── tests/                        # pytest suite for the src/ modules
+│   ├── test_data_processing.py
+│   ├── test_features.py
+│   └── test_evaluate.py
 │
 ├── 02_data/
 │   ├── raw/                      # place accepted_2007_to_2018Q4.csv here (untracked)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# The tests import from src/, which lives at the repository root.
+pythonpath = .
+testpaths = tests

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -25,6 +25,7 @@ def test_rm_nas_keeps_a_column_exactly_at_the_threshold():
 
 
 def test_rm_nas_leaves_complete_data_untouched():
+    """No column has missing values, so none can exceed the threshold."""
     df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
     assert_frame_equal(rm_nas(df), df)
 

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,78 @@
+"""Tests for the cleaning steps in :mod:`src.data_processing`."""
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from src.data_processing import create_target, drop_leakage_columns, rm_nas
+
+
+def test_rm_nas_drops_only_columns_above_the_threshold():
+    """A column with 60% missing goes, one with 20% stays."""
+    df = pd.DataFrame(
+        {
+            "sparse": [1.0, None, None, None, None],
+            "dense": [1.0, 2.0, 3.0, 4.0, None],
+        }
+    )
+    assert list(rm_nas(df).columns) == ["dense"]
+
+
+def test_rm_nas_keeps_a_column_exactly_at_the_threshold():
+    """The threshold is exclusive: 40% missing is still acceptable."""
+    df = pd.DataFrame({"edge": [1.0, 2.0, 3.0, None, None]})
+    assert list(rm_nas(df).columns) == ["edge"]
+
+
+def test_rm_nas_leaves_complete_data_untouched():
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    assert_frame_equal(rm_nas(df), df)
+
+
+@pytest.mark.parametrize(
+    "df",
+    [pd.DataFrame(), pd.DataFrame(columns=["a", "b"])],
+    ids=["no rows and no columns", "columns but no rows"],
+)
+def test_rm_nas_handles_empty_input(df):
+    """An empty frame has no missing share to exceed the threshold."""
+    assert_frame_equal(rm_nas(df), df)
+
+
+def test_drop_leakage_columns_removes_post_outcome_and_irrelevant_columns():
+    """Post-outcome fields go, features known at origination stay.
+
+    ``fico_range_low`` is the interesting case: it looks like the dropped
+    ``last_fico_range_low`` but is the score at origination and must survive.
+    """
+    df = pd.DataFrame(
+        {
+            "loan_amnt": [1000],
+            "fico_range_low": [700],
+            "target": [0],
+            "recoveries": [0.0],
+            "last_fico_range_low": [650],
+            "hardship_type": ["INTEREST ONLY-3 MONTHS DEFERRAL"],
+            "settlement_amount": [500.0],
+            "grade": ["B"],
+            "url": ["https://example.com"],
+        }
+    )
+    result = drop_leakage_columns(df)
+    assert list(result.columns) == ["loan_amnt", "fico_range_low", "target"]
+
+
+def test_drop_leakage_columns_ignores_columns_that_are_absent():
+    """Most deny-listed columns are already gone by the time this runs."""
+    df = pd.DataFrame({"loan_amnt": [1000], "total_pymnt": [500.0]})
+    assert list(drop_leakage_columns(df).columns) == ["loan_amnt"]
+
+
+def test_create_target_keeps_completed_loans_and_encodes_the_outcome():
+    """Running loans have no known outcome and must not become non-defaults."""
+    df = pd.DataFrame(
+        {"loan_status": ["Fully Paid", "Charged Off", "Current", "Late (31-120 days)"]}
+    )
+    result = create_target(df)
+    assert list(result["loan_status"]) == ["Fully Paid", "Charged Off"]
+    assert list(result["target"]) == [0, 1]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -19,11 +19,15 @@ class FixedProbaModel:
         self.y_pred_proba = np.asarray(y_pred_proba)
 
     def predict_proba(self, x_test: pd.DataFrame) -> np.ndarray:
-        """:return: The two-column probability matrix sklearn models return."""
+        """:param x_test: Ignored; the probabilities are fixed at construction.
+        :return: The two-column probability matrix sklearn models return.
+        """
         return np.column_stack([1 - self.y_pred_proba, self.y_pred_proba])
 
     def predict(self, x_test: pd.DataFrame) -> np.ndarray:
-        """:return: The 0.5-threshold labels sklearn classifiers predict."""
+        """:param x_test: Ignored; see :meth:`predict_proba`.
+        :return: The 0.5-threshold labels sklearn classifiers predict.
+        """
         return (self.y_pred_proba >= 0.5).astype(int)
 
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,79 @@
+"""Tests for the metric computation in :mod:`src.evaluate`."""
+
+import numpy as np
+import pandas as pd
+
+from src.evaluate import evaluate_model
+
+
+class FixedProbaModel:
+    """Stand-in for a fitted classifier with known predicted probabilities.
+
+    ``evaluate_model`` only calls ``predict_proba`` and ``predict``, so the
+    metrics can be checked against hand-computed values instead of against
+    whatever a model trained on synthetic data happens to produce.
+    """
+
+    def __init__(self, y_pred_proba: list[float]) -> None:
+        """:param y_pred_proba: Default probability per test row."""
+        self.y_pred_proba = np.asarray(y_pred_proba)
+
+    def predict_proba(self, x_test: pd.DataFrame) -> np.ndarray:
+        """:return: The two-column probability matrix sklearn models return."""
+        return np.column_stack([1 - self.y_pred_proba, self.y_pred_proba])
+
+    def predict(self, x_test: pd.DataFrame) -> np.ndarray:
+        """:return: The 0.5-threshold labels sklearn classifiers predict."""
+        return (self.y_pred_proba >= 0.5).astype(int)
+
+
+def _evaluate(y_true: list[int], y_pred_proba: list[float]) -> dict[str, object]:
+    """Run :func:`evaluate_model` on hand-picked scores.
+
+    :param y_true: True labels.
+    :param y_pred_proba: Predicted default probability per row.
+    :return: The metrics dict.
+    """
+    x_test = pd.DataFrame({"feature": range(len(y_true))})
+    return evaluate_model(FixedProbaModel(y_pred_proba), x_test, pd.Series(y_true))
+
+
+def test_perfect_separation_scores_the_maximum():
+    """Every defaulted loan scored above every repaid one: AUC, Gini and KS 1."""
+    result = _evaluate([0, 0, 0, 1, 1, 1], [0.1, 0.2, 0.3, 0.7, 0.8, 0.9])
+    assert result["roc_auc"] == 1.0
+    assert result["gini"] == 1.0
+    assert result["ks"] == 1.0
+
+
+def test_overlapping_scores_match_the_hand_computed_values():
+    """Three of the four default/non-default pairs are ranked correctly.
+
+    Scores are 0.1 and 0.6 for the repaid loans, 0.4 and 0.9 for the defaulted
+    ones, so AUC is 3/4 and Gini 2 * 0.75 - 1. The score distributions differ
+    most below 0.4 and above 0.6, in both cases by one of two observations, so
+    KS is 0.5.
+    """
+    result = _evaluate([0, 0, 1, 1], [0.1, 0.6, 0.4, 0.9])
+    assert result["roc_auc"] == 0.75
+    assert result["gini"] == 0.5
+    assert result["ks"] == 0.5
+
+
+def test_predicted_probabilities_are_handed_out_unchanged():
+    """The notebook plots and explains these, so they must be the raw scores."""
+    result = _evaluate([0, 1], [0.25, 0.75])
+    assert list(result["y_pred_proba"]) == [0.25, 0.75]
+
+
+def test_metrics_are_positional_for_a_non_zero_based_index():
+    """``y_test`` arrives from ``train_test_split`` with the original index.
+
+    The KS split masks a numpy array with a pandas Series, which uses the
+    values rather than the labels; this test fails if that ever changes.
+    """
+    x_test = pd.DataFrame({"feature": range(4)})
+    y_test = pd.Series([0, 0, 1, 1], index=[7, 42, 13, 99])
+    result = evaluate_model(FixedProbaModel([0.1, 0.6, 0.4, 0.9]), x_test, y_test)
+    assert result["roc_auc"] == 0.75
+    assert result["ks"] == 0.5

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,47 @@
+"""Tests for the feature engineering in :mod:`src.features`."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from src.features import convert_emp_length, engineer_features
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("< 1 year", 0),
+        ("1 year", 1),
+        ("3 years", 3),
+        ("10+ years", 10),
+        (np.nan, 0),
+    ],
+)
+def test_convert_emp_length(value, expected):
+    assert convert_emp_length(value) == expected
+
+
+def test_engineer_features_makes_every_column_numeric():
+    """``term`` and ``emp_length`` become numbers, the rest is one-hot encoded.
+
+    ``drop_first=True`` keeps only the ``RENT`` dummy: ``OWN`` is the reference
+    category and is implied by all dummies being false.
+    """
+    df = pd.DataFrame(
+        {
+            "term": [" 36 months", " 60 months"],
+            "emp_length": ["3 years", "10+ years"],
+            "home_ownership": ["RENT", "OWN"],
+            "target": [0, 1],
+        }
+    )
+    expected = pd.DataFrame(
+        {
+            "term": [36, 60],
+            "emp_length": [3, 10],
+            "target": [0, 1],
+            "home_ownership_RENT": [True, False],
+        }
+    )
+    assert_frame_equal(engineer_features(df), expected)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -19,6 +19,7 @@ from src.features import convert_emp_length, engineer_features
     ],
 )
 def test_convert_emp_length(value, expected):
+    """``< 1 year`` and missing both collapse to 0; ``10+ years`` caps at 10."""
     assert convert_emp_length(value) == expected
 
 


### PR DESCRIPTION
## Summary

The repository had no tests at all. This adds a `tests/` suite for the deterministic building blocks in `src/` — the cleaning steps, the feature engineering and the metric computation — plus the `pytest.ini` that makes `pytest` work from the repository root and a README step describing how to run it. 18 tests, all green.

## Type of change
- [ ] Bugfix
- [ ] New feature / analysis
- [ ] Refactoring (keine Verhaltensänderung)
- [x] Documentation — README gets the "run the tests" step
- [ ] Model/metrics change

No production code is touched: `src/` and the notebook are unchanged.

## Related issue

Issue #6. `Closes #6` does not fire here because this PR targets the integration branch, not the default branch — the reviewer closes the issue manually after the merge.

## Changes

**`tests/test_data_processing.py`** (7 tests)
- `rm_nas`: a column 60% missing is dropped while one 20% missing stays; a column at exactly 40% stays (the threshold is exclusive — `per > threshold` — which is the kind of boundary that gets flipped by accident); complete data comes back unchanged; both empty shapes (no rows and no columns, columns but no rows) are handled rather than raising.
- `drop_leakage_columns`: post-outcome fields, `hardship_*`/`settlement_*` prefixes and irrelevant identifier columns all go in one call, while `loan_amnt`, `target` and — the case worth pinning — `fico_range_low` survive. That last one is one character away from the dropped `last_fico_range_low` and is the origination score the model is allowed to see, so a sloppier substring match in `drop_leakage_columns` would silently cost a feature. A second test covers the missing-column case the issue names explicitly: by the time this function runs, most deny-listed columns are already gone via `rm_nas`, so `errors="ignore"` has to hold.
- `create_target`: running and late loans are excluded rather than labelled as non-defaults, and `Charged Off` maps to 1.

**`tests/test_features.py`** (6 tests)
- `convert_emp_length` parametrized over `< 1 year`, `1 year`, `3 years`, `10+ years` and `NaN`.
- `engineer_features` against an explicit expected frame with `assert_frame_equal` (as step 5 of the issue asks): `term` becomes `36`/`60`, `emp_length` becomes years, and the one categorical column becomes a single `home_ownership_RENT` dummy, `OWN` being the reference category under `drop_first=True`.

**`tests/test_evaluate.py`** (5 tests)
- A small `FixedProbaModel` stands in for the fitted classifier. `evaluate_model` only calls `predict_proba` and `predict`, so this keeps the expected metrics hand-derivable instead of reading them off a model trained on synthetic data — which is what step 6 of the issue asks for ("mit bekannten Beispielwerten die korrekte Metrikberechnung verifizieren").
- Perfect separation gives AUC, Gini and KS of exactly 1.
- The overlapping case is worked out in the docstring: scores 0.1/0.6 for the repaid loans and 0.4/0.9 for the defaulted ones rank three of the four pairs correctly, so AUC is 0.75, Gini 0.5 and KS 0.5.
- `y_pred_proba` is handed back unchanged (the notebook plots and interprets it).
- One regression test pins what the PR #19 review had to verify by hand: `y_test` arrives from `train_test_split` carrying the original index, and the KS split masks a numpy array with a pandas Series, which uses values rather than labels. With an index of `[7, 42, 13, 99]` the metrics must be unchanged.

**`pytest.ini`** — three lines: `pythonpath = .` so the tests can `from src... import`, and `testpaths = tests`. The alternative was an empty root `conftest.py`, which achieves the same by side effect; the explicit config seemed better to read, and #13 can build on it in CI.

**`README.md`** — a step 4 in "How to run" (`pytest`, with a sentence on what `pytest.ini` does), plus `pytest.ini` and `tests/` in the repository layout block.

## Model/Data-Leakage-Check
- [x] Beeinflusst dieser PR Trainingsdaten, Features oder das Modell? **No.** Test-only; no file under `src/` or `01_notebooks/` is modified.
- [x] Falls ja: alte vs. neue Metriken — not applicable.
- [x] Keine neuen Features verwendet, die erst nach Kreditvergabe/Ausfall bekannt sind — the opposite: `test_drop_leakage_columns_removes_post_outcome_and_irrelevant_columns` is a guard against exactly that regression.
- [x] Ein auffällig hoher/niedriger Metrikwert wurde erklärt — the AUC of 1.0 in the perfect-separation test is a constructed input, and the docstring says so.

## How to test / Verification

```
$ pytest
18 passed, 1 warning in 1.53s
```

Run against the pinned versions from #7 — `pandas 3.0.5`, `numpy 2.4.6`, `scikit-learn 1.9.0`, `scipy 1.17.1`, `pytest 9.1.1` — installed fresh in this session, which incidentally re-confirms those pins install cleanly. `black --check` and `ruff check` pass on `tests/` and `src/`.

The expected values in `test_evaluate.py` were derived by hand (pair counting for AUC, ECDF gaps for KS) before the run, not copied from the output.

### One thing the run surfaced, deliberately not fixed here

`pytest` reports a single warning, and it comes from existing code rather than from the tests: `src/features.py:35` calls `select_dtypes(include=["object"])`, and pandas 3 warns that `object` still picks up the new `str` dtype for backward compatibility and will stop doing so. The behaviour is correct today and the fix (`include=["str", "object"]`) is a change to `src/`, which is outside this issue — issue #12 explicitly owns "Warnings gezielt behandeln". Flagged for the reviewer and recorded in `HANDOVER.md`.

### Scope decisions

- **`pytest-cov` left out.** The issue says "ggf."; nothing in the repo consumes a coverage report, and #13 has not decided whether CI publishes one. Adding it now would be a dependency on a guess — the same reasoning that kept `optbinning` out in #7.
- **No tests for `train.py` or `load_raw_data`.** `split_and_scale` and `train_model` are thin wrappers around scikit-learn, and the issue asks for the functions "bei denen ein Test echten Mehrwert hat". Testing that `train_test_split` splits, or that `read_csv` reads, tests scikit-learn and pandas rather than this repository.

## Checklist
- [x] Notebook läuft sauber von oben nach unten durch — unchanged by this PR; no notebook cell is touched
- [x] Tests laufen durch (`pytest tests/`) — 18 passed
- [x] README ggf. aktualisiert und weiterhin konsistent mit dem tatsächlichen Repo-Inhalt — new test step, and `tests/` plus `pytest.ini` added to the layout block
- [x] Keine Secrets/Zugangsdaten committet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KmnFqcETbyCyKAN6WDmHj

---
_Generated by [Claude Code](https://claude.ai/code/session_013KmnFqcETbyCyKAN6WDmHj)_