### PR TITLE
docs: place the project in its Basel / IFRS 9 / FINMA context (#11)

### DIFF
--- a/01_notebooks/prediction.ipynb
+++ b/01_notebooks/prediction.ipynb
@@ -20,7 +20,17 @@
     "```\n",
     "\n",
     "The raw CSV (~1.6 GB) is not part of this repository; it comes from the\n",
-    "LendingClub dataset on Kaggle."
+    "LendingClub dataset on Kaggle.\n",
+    "\n",
+    "**Scope.** The model estimates a probability of default only. LGD (loss given\n",
+    "default) and EAD (exposure at default), the other two inputs a bank needs for an\n",
+    "expected-loss or a capital figure, are not modelled here. And this is a portfolio\n",
+    "project on public historical data, not a supervisory-approved rating system: the\n",
+    "target is a write-off rather than the regulatory default definition, the horizon\n",
+    "is the loan's whole term rather than one year, and none of the calibration or\n",
+    "validation that a rating system requires has been done. The README section\n",
+    "\"Regulatory context\" spells out where the project sits relative to Basel and\n",
+    "IFRS 9, and what it deliberately leaves out."
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ credit-risk-modelling/
 ├── tests/                        # pytest suite for the src/ modules
 │   ├── test_data_processing.py
 │   ├── test_features.py
-│   └── test_evaluate.py
+│   ├── test_evaluate.py
+│   └── test_train.py
 │
 ├── 02_data/
 │   ├── raw/                      # place accepted_2007_to_2018Q4.csv here (untracked)
@@ -177,6 +178,101 @@ Two things are worth stating up front about how those numbers should be read:
   predicted probabilities are deliberately shifted and cannot be used as PDs in
   an expected-loss calculation without recalibration. That is acceptable for a
   ranking model, but it has to be said rather than assumed.
+
+## Regulatory context
+
+A PD model is not a free-standing object: in a bank it is an input to two
+different regulatory calculations. Being precise about which part of them this
+project touches is more useful than claiming to cover them.
+
+### Basel: PD is one of three inputs, and only one is built here
+
+Under the internal ratings-based (IRB) approach, the capital requirement for a
+credit exposure comes out of a supervisory risk-weight function fed by three
+estimates:
+
+| Input | Question it answers | Here |
+| --- | --- | --- |
+| **PD** — probability of default | How likely is this borrower to default? | modelled |
+| **LGD** — loss given default | If they default, what share of the exposure is lost? | not modelled |
+| **EAD** — exposure at default | How much is outstanding at that moment? | not modelled |
+
+Expected loss is `PD x LGD x EAD`, so a PD model on its own answers one third of
+the question. For a fully drawn, amortising consumer loan EAD holds few
+surprises — it is close to the outstanding balance. LGD is a genuine second
+modelling problem: recovery on unsecured consumer debt is driven by collections
+behaviour rather than by collateral, and this project does not attempt it.
+
+Two further details decide how the numbers here may be read:
+
+- **The default definition is not the regulatory one.** Basel defines default as
+  90 days past due or unlikeliness to pay. The target here is LendingClub's
+  `Charged Off` status, which is a write-off — a later and stricter event that a
+  loan reaches long after it would already have counted as defaulted under the
+  regulatory definition. The two are not interchangeable, and a model trained on
+  one does not estimate the other.
+- **The horizon is not the regulatory one.** An IRB PD is a one-year
+  probability. This model is fitted at origination against the outcome over the
+  loan's entire 36- or 60-month term, which makes it closer to a lifetime PD.
+
+### IFRS 9: PD drives the loss allowance and the staging
+
+IFRS 9 requires expected credit losses (ECL) to be recognised up front rather
+than waiting for a loss event, and PD is the first factor of the same
+`ECL = PD x LGD x EAD`, discounted. Which PD is required depends on the stage
+the exposure sits in:
+
+| Stage | Condition | Allowance |
+| --- | --- | --- |
+| 1 | no significant increase in credit risk since initial recognition | 12-month ECL |
+| 2 | significant increase in credit risk, not credit-impaired | lifetime ECL |
+| 3 | credit-impaired | lifetime ECL, interest on the net carrying amount |
+
+The staging is where the two frameworks pull apart. IFRS 9 PDs are
+point-in-time and forward-looking — conditioned on where the cycle currently is
+and on macroeconomic scenarios. Basel IRB PDs are deliberately the opposite:
+long-run averages, insensitive to the cycle by design. One estimate cannot be
+both, which is why banks maintain separate PD models for the two purposes
+instead of reusing one.
+
+### Switzerland
+
+FINMA implements the Basel framework through the Capital Adequacy Ordinance and
+its circulars. In practice the standardised approach dominates: risk weights
+come from a supervisory table and no internal PD enters the capital calculation
+at all. Internal PD models under IRB require explicit FINMA approval and are
+used by only a small number of institutions. Provisioning splits along a similar
+line — banks reporting under IFRS apply IFRS 9, while banks reporting under the
+Swiss accounting rules follow FINMA's own expected-loss provisioning
+requirements, which are graduated by the category of the institution. The
+vocabulary above therefore travels to a Swiss bank; which of the two regimes
+that bank actually applies does not follow from it.
+
+### What this project is not
+
+A learning and portfolio project on a public historical dataset from a US
+peer-to-peer lending platform. It is **not** a supervisory-approved model and
+makes no claim to satisfy any regulatory requirement. Beyond the default
+definition and the horizon above, it lacks essentially everything that turns a
+classifier into a rating system:
+
+- **No calibration.** `class_weight="balanced"` shifts the predicted
+  probabilities away from the observed default rate on purpose (see "Results"),
+  so the output ranks borrowers rather than estimating a PD level — and there is
+  neither a through-the-cycle nor a point-in-time calibration on top, so it fits
+  neither definition even after recalibration.
+- **No rating system.** No grades, no masterscale, no margin of conservatism.
+- **No validation in the supervisory sense.** No out-of-time testing, no
+  independent validation function, no annual review, no ongoing monitoring, no
+  override policy, no model documentation of the kind a validation unit means.
+- **No representativeness argument.** One platform, one country, one time
+  window. Nothing has been established about how that relates to any bank's own
+  portfolio.
+
+None of this makes the exercise idle. The steps are the ones a real PD project
+runs: the leakage correction, the origination-only feature set, the scorecard
+benchmark, the discrimination and calibration metrics. It does mean the result
+is a demonstration of method, not a PD.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ project touches is more useful than claiming to cover them.
 ### Basel: PD is one of three inputs, and only one is built here
 
 Under the internal ratings-based (IRB) approach, the capital requirement for a
-credit exposure comes out of a supervisory risk-weight function fed by three
-estimates:
+retail exposure — the category a consumer loan falls into — comes out of a
+supervisory risk-weight function fed by three estimates (outside retail the
+effective maturity enters as a fourth):
 
 | Input | Question it answers | Here |
 | --- | --- | --- |

--- a/plans/2026-09-04_basel-ifrs9-context.md
+++ b/plans/2026-09-04_basel-ifrs9-context.md
@@ -1,0 +1,45 @@
+# Basel / IFRS 9 / FINMA context (issue #11)
+
+## Goal
+
+Place the project in the regulatory context PD models are actually used in,
+without claiming it meets any regulatory requirement.
+
+## What already exists
+
+Three pieces of the issue are already in the notebook and must not be
+duplicated:
+
+- Section 5 puts the AUC/Gini/KS in relation to the usual retail range
+  (Gini 0.30-0.50, KS 0.20-0.35) — that is step 2 of the issue, delivered by #8.
+- The calibration cell already states `ECL = PD x LGD x EAD` and why
+  `class_weight="balanced"` makes the output unusable as a PD (#8).
+- Section 7 already contrasts an IRB rating system with an IFRS 9 PD as the two
+  cases where interpretability outweighs discrimination (#10).
+
+What is missing is the framing itself: which of the three Basel inputs this
+project builds, how the target and the horizon differ from the regulatory
+definitions, how IFRS 9 staging uses a PD, the Swiss implementation, and an
+explicit list of what makes this not a rating system.
+
+## Steps
+
+1. `README.md`: new section "Regulatory context" between "Results" and
+   "License" — Basel PD/LGD/EAD split, the two mismatches (default definition,
+   horizon), IFRS 9 ECL and stages 1/2/3, PIT vs TTC, FINMA implementation,
+   then "What this project is not".
+   -> verify: no sentence claims compliance; every regulatory statement is
+   either definitional or hedged.
+2. `01_notebooks/prediction.ipynb`: one scope paragraph in the intro cell,
+   pointing at the README section rather than repeating it.
+   -> verify: a copy of the notebook still executes top to bottom.
+3. Carried over from #10: `tests/test_train.py` is missing from the README
+   layout block. One line, disclosed in the PR as out of scope.
+
+## Decisions
+
+- No new "section 8" in the notebook. The regulatory material belongs in the
+  README; the notebook gets the scope statement only, so the two do not drift
+  apart.
+- `plans/` is created here because `CLAUDE_CODING_RULES.md` requires it.
+  Issues #2-#10 did not do this — recorded in `HANDOVER.md` for the user.


### PR DESCRIPTION
## Summary

Das Projekt sagt eine PD vorher, hat aber nirgends gesagt, wozu eine PD in einer Bank überhaupt dient — und, wichtiger, was diese PD von einer regulatorischen unterscheidet. Dieser PR ergänzt den Abschnitt "Regulatory context" im README und eine Scope-Aussage im Notebook. Keine Code-, Modell- oder Metrikänderung.

Der Schwerpunkt liegt bewusst auf der Abgrenzung: die zwei konkreten Mismatches (Ausfalldefinition, Horizont) werden benannt, statt sie zu übergehen.

## Type of change
- [ ] Bugfix
- [ ] New feature / analysis
- [ ] Refactoring (keine Verhaltensänderung)
- [x] Documentation
- [ ] Model/metrics change

## Related issue

Issue #11 — Basel/IFRS9-Einordnung ergänzen.
(`Closes #11` schließt bei einem PR gegen einen Nicht-Default-Branch nicht automatisch; die Reviewer-Session schließt das Issue nach dem Merge manuell.)

## Changes

**`README.md` — neuer Abschnitt "Regulatory context"** zwischen "Results" und "License", vier Unterabschnitte:

- **Basel.** PD/LGD/EAD als die drei Inputs der IRB-Risikogewichtsfunktion, als Tabelle mit einer "Here"-Spalte, die für LGD und EAD ehrlich "not modelled" sagt. Dazu, warum EAD bei einem voll ausgezahlten Ratenkredit wenig hergibt und LGD bei unbesichertem Konsumentenkredit ein eigenes Modellierungsproblem ist.
- **Die zwei Mismatches, explizit.** Basel definiert Ausfall als 90 Tage überfällig oder unwahrscheinliche Rückzahlung — das Ziel hier ist `Charged Off`, also eine Abschreibung und damit ein späteres, strengeres Ereignis. Und eine IRB-PD ist eine Einjahres-Wahrscheinlichkeit, während dieses Modell bei Origination gegen den Ausgang über die volle Laufzeit (36/60 Monate) geschätzt wird, also eher eine Lifetime-PD ist. Beides ist nicht austauschbar, und das steht jetzt da.
- **IFRS 9.** `ECL = PD x LGD x EAD`, Staging 1/2/3 als Tabelle (Bedingung + Wertberichtigung), und der Punkt, an dem die beiden Rahmenwerke auseinanderlaufen: IFRS-9-PDs sind Point-in-Time und zukunftsgerichtet, IRB-PDs bewusst langfristige Durchschnitte. Ein Modell kann nicht beides sein — deshalb halten Banken zwei getrennte PD-Schätzungen.
- **Schweiz.** FINMA setzt Basel über die Eigenmittelverordnung und die Rundschreiben um; in der Praxis dominiert der Standardansatz, in dem gar keine interne PD in die Eigenmittelrechnung eingeht, und IRB braucht eine explizite FINMA-Bewilligung. Bei der Vorsorge dieselbe Zweiteilung: IFRS-Berichterstatter wenden IFRS 9 an, Banken nach den Schweizer Rechnungslegungsvorschriften die nach Bankenkategorie abgestuften FINMA-Anforderungen.
- **"What this project is not".** Kein aufsichtsrechtlich abgenommenes Modell, mit einer konkreten Liste statt einer Floskel: keine Kalibrierung (`class_weight="balanced"` verschiebt die Wahrscheinlichkeiten absichtlich, und darüber liegt weder eine TTC- noch eine PIT-Kalibrierung), keine Ratingklassen/Masterscale/Konservativitätsmarge, keine Out-of-Time- oder unabhängige Validierung, kein Monitoring, keine Repräsentativitätsargumentation. Schließt damit, dass die *Methode* trotzdem die richtige ist — das Ergebnis ist eine Demonstration des Verfahrens, keine PD.

**`01_notebooks/prediction.ipynb`** — ein Absatz "Scope" in der Einleitungszelle: nur PD, nicht LGD/EAD; Portfolio-Projekt, kein bewilligtes Ratingsystem; Ziel ist eine Abschreibung, Horizont ist die Laufzeit. Verweist auf den README-Abschnitt, statt ihn zu wiederholen.

**`plans/2026-09-04_basel-ifrs9-context.md`** — der Plan, wie `CLAUDE_CODING_RULES.md` es verlangt (siehe "Anmerkungen" unten).

### Was bewusst *nicht* gemacht wurde

- **Kein neuer Notebook-Abschnitt 8.** Der regulatorische Stoff gehört ins README; das Notebook bekommt nur die Scope-Aussage, damit die beiden nicht auseinanderdriften. Ein zweiter Ort für dieselben Aussagen wäre eine Wartungslast ohne Gegenwert.
- **Schritt 2 des Issues ist bereits erledigt** und wurde nicht dupliziert. Notebook-Zelle 24 stellt AUC/Gini/KS schon in Bezug zu den üblichen Retail-Bandbreiten (Gini 0.30-0.50, KS 0.20-0.35, mit dem Hinweis, dass deutlich höhere Werte eine Leakage-Warnung sind) — das kam mit #8. Ebenso steht `ECL = PD x LGD x EAD` bereits in der Kalibrierungszelle und die IRB-/IFRS-9-Gegenüberstellung in Abschnitt 7 (#10). Der PR ergänzt nur, was fehlte: die Einordnung selbst.

## Model/Data-Leakage-Check
- [x] Beeinflusst dieser PR Trainingsdaten, Features oder das Modell? — **Nein.** Kein Python-Code geändert, `git diff --stat` ist README + Notebook-Markdown + Plan.
- [ ] Falls ja: alte vs. neue Metriken — entfällt.
- [x] Keine neuen Features verwendet, die erst nach Kreditvergabe bekannt sind — es werden gar keine Features geändert.
- [x] Ein auffällig hoher/niedriger Metrikwert wurde erklärt, nicht nur berichtet — es wird kein Metrikwert berichtet.

## How to test / Verification

- Eine *Kopie* des Notebooks mit `nbclient` gegen einen synthetischen LendingClub-förmigen CSV (6000 Zeilen, 42 Spalten) ausgeführt: alle 25 Code-Zellen laufen durch, Zählstände 1-25. Kopie und CSV wurden nicht committet; das committete Notebook behält leere Outputs.
- `pytest`: `20 passed, 1 warning` (die Warnung stammt aus `src/features.py:35` und gehört zu #12).
- Kein Code geändert, daher kein `black`/`ruff`-Lauf nötig — die Prüfung lief in dieser Session trotzdem sauber durch.
- README-Abschnitt gegen die Aussagen im Repo geprüft: die Ausfalldefinition entspricht `COMPLETED_STATUSES`/`create_target` in `src/data_processing.py`, der Laufzeit-Horizont der 36/60-Monats-`term`-Spalte, und die Kalibrierungsaussage dem `class_weight="balanced"` in `src/train.py`.

## Checklist
- [x] Notebook läuft sauber von oben nach unten durch
- [x] Tests laufen durch (`pytest`)
- [x] README ggf. aktualisiert und weiterhin konsistent mit dem tatsächlichen Repo-Inhalt
- [x] Keine Secrets/Zugangsdaten committet

## Anmerkungen für den Reviewer

1. **Eine Zeile außerhalb des Scopes.** Der Repository-Layout-Block im README listete `tests/test_train.py` nicht, obwohl #10 die Datei angelegt hat. Da dieser PR ohnehin genau diese Datei anfasst und #3 den Block ausdrücklich als wahrheitsgetreu pflegt, ist die Zeile hier ergänzt statt stehen gelassen — bewusst gemeldet, nicht versteckt.
2. **`plans/` existiert bisher nicht.** `CLAUDE_CODING_RULES.md` verlangt für jede Umsetzung einen Plan unter `plans/YYYY-MM-DD_name.md`, aber die Issues #2-#10 haben das nie getan. Hier ist die Regel befolgt worden; das macht diesen PR aber inkonsistent mit den neun vorherigen. Entweder wird das rückwirkend nachgezogen oder die Regel angepasst — das ist eine Entscheidung des Nutzers und in `HANDOVER.md` vermerkt.
3. **Fachliche Aussagen bitte gegenlesen.** Der Abschnitt macht regulatorische Aussagen, die in einem Bewerbungs-Repo falsch dazustehen teuer wäre. Die riskantesten sind bewusst konservativ formuliert: keine Basel-Artikelnummern, keine Input-Floor-Prozentsätze, kein FINMA-Rundschreiben mit Nummer, keine Namen einzelner Banken und ihrer Rechnungslegung. Wenn etwas trotzdem zu weit geht, lieber streichen als abschwächen.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rRZKgVb7CWhu8HTRUA82A

---
_Generated by [Claude Code](https://claude.ai/code/session_019rRZKgVb7CWhu8HTRUA82A)_