### PR TITLE
ci: add GitHub Actions workflow for lint, format and tests (#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           # The pins in requirements.txt were resolved together on 3.11.
           python-version: "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Linting, formatting and tests on every push to main and on every pull
+# request. The tests run on small synthetic DataFrames, so CI needs no access
+# to the ~1.6 GB raw dataset.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # The pins in requirements.txt were resolved together on 3.11.
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Lint
+        run: ruff check .
+
+      # Scoped to the Python sources: the notebook is not black-formatted, and
+      # reformatting it is not this workflow's job.
+      - name: Check formatting
+        run: black --check src tests
+
+      - name: Test
+        run: pytest tests/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Credit Risk Modelling
 
+[![CI](https://github.com/FelixSchramm/credit-risk-modelling/actions/workflows/ci.yml/badge.svg)](https://github.com/FelixSchramm/credit-risk-modelling/actions/workflows/ci.yml)
+
 A probability-of-default (PD) model on the historical LendingClub dataset
 (2007-2018Q4). The task is to estimate, at the moment of application, how likely
 a loan is to end as "Charged Off" — the question a credit risk function answers
@@ -83,6 +85,10 @@ credit-risk-modelling/
 ├── requirements.txt
 ├── pytest.ini
 ├── .gitignore
+│
+├── .github/
+│   ├── pull_request_template.md
+│   └── workflows/ci.yml          # lint, format and tests on push/PR
 │
 ├── 01_notebooks/
 │   └── prediction.ipynb          # the analysis: EDA, cleaning, model, evaluation

--- a/plans/2026-09-05_ci-setup.md
+++ b/plans/2026-09-05_ci-setup.md
@@ -38,8 +38,11 @@ every pull request, and the result is visible in the README.
   the same command passes or fails depending on whether `tokenize-rt` got
   pulled in transitively. Naming the directories makes CI deterministic.
   `ruff check .` stays unscoped — it covers the notebook and passes.
-- **Actions pinned to `actions/checkout@v4` and `actions/setup-python@v5`,**
-  the majors that are current and known-good, rather than guessing at newer
-  ones from a workflow that cannot be dry-run.
+- **Actions pinned to `actions/checkout@v5` and `actions/setup-python@v6`.**
+  The first run used `@v4`/`@v5`, chosen conservatively because a workflow
+  cannot be dry-run. That run went green but warned: "Node.js 20 is
+  deprecated. The following actions target Node.js 20 but are being forced to
+  run on Node.js 24." The bump is the documented fix; the workflow run itself
+  is the evidence that the newer majors resolve.
 - **No dataset step.** The tests use small synthetic DataFrames, so CI needs no
   access to the ~1.6 GB Kaggle CSV.

--- a/plans/2026-09-05_ci-setup.md
+++ b/plans/2026-09-05_ci-setup.md
@@ -1,0 +1,45 @@
+# CI setup with GitHub Actions (issue #13)
+
+## Goal
+
+Linting, formatting and tests run automatically on every push to `main` and
+every pull request, and the result is visible in the README.
+
+## Steps
+
+1. `.github/workflows/ci.yml`: one job on `ubuntu-latest` — checkout,
+   `actions/setup-python` with `cache: pip`, `pip install -r requirements.txt`,
+   `ruff check .`, `black --check src tests`, `pytest tests/`.
+   -> verify: all three commands pass locally on the pinned versions before the
+   workflow is pushed.
+2. Trigger on `push` to `main` and on `pull_request` (unfiltered, so PRs into
+   the integration branch are covered too).
+   -> verify: the PR for this issue itself makes the workflow run.
+3. CI badge in the README, plus `.github/` in the repository-layout block,
+   which #3 established as maintained-as-truth.
+   -> verify: the badge URL matches the workflow file name.
+4. The run on this PR must be green.
+   -> verify: check the PR's check runs after pushing.
+
+## Decisions
+
+- **Python 3.11.** `requirements.txt` states its pins were resolved together on
+  3.11; using anything else in CI would test a combination nobody validated.
+- **`black --check` is in the pipeline although the issue names only `ruff`.**
+  The issue's "one tool is enough" argument is about ruff replacing
+  `flake8`/`isort` as a *linter*; `CLAUDE_CODING_RULES.md` separately requires
+  black for formatting and points at this issue for the enforcement.
+- **`black --check src tests`, not `black --check .`.** Two reasons, both
+  measured rather than assumed. The notebook is not black-formatted
+  (`black --check .` reports `01_notebooks/prediction.ipynb` would be
+  reformatted), and reformatting the notebook that #5 curated is not this
+  issue's job. Worse, `black --check .` is *unstable*: black silently skips
+  `.ipynb` files unless the `black[jupyter]` extras happen to be present, so
+  the same command passes or fails depending on whether `tokenize-rt` got
+  pulled in transitively. Naming the directories makes CI deterministic.
+  `ruff check .` stays unscoped — it covers the notebook and passes.
+- **Actions pinned to `actions/checkout@v4` and `actions/setup-python@v5`,**
+  the majors that are current and known-good, rather than guessing at newer
+  ones from a workflow that cannot be dry-run.
+- **No dataset step.** The tests use small synthetic DataFrames, so CI needs no
+  access to the ~1.6 GB Kaggle CSV.


### PR DESCRIPTION
## Summary

Implements issue #13, the last issue of the work plan. The repo had no CI at all, so nothing enforced the checks every session ran by hand. One job now runs linting, formatting and the test suite on every push to `main` and every pull request, and the README carries the status badge.

## Type of change
- [ ] Bugfix
- [ ] New feature / analysis
- [ ] Refactoring (keine Verhaltensänderung)
- [x] Documentation
- [ ] Model/metrics change

(Closest fit — the change is pure repository infrastructure; no analysis code is touched.)

## Related issue

Issue #13 — CI-Setup (GitHub Actions für Lint/Tests).

`Closes #13` is deliberately omitted: GitHub does not auto-close for PRs into a non-default branch, so the reviewer closes the issue manually after the merge.

## Changes

- **`.github/workflows/ci.yml`** (new) — one job, `lint-and-test`, on `ubuntu-latest`:
  `actions/checkout@v4` → `actions/setup-python@v5` (Python 3.11, `cache: pip`) →
  `pip install -r requirements.txt` → `ruff check .` → `black --check src tests` → `pytest tests/`.
  Triggers: `push` to `main`, and `pull_request` unfiltered — so PRs into the integration branch are covered too, which is what makes this PR itself the acceptance test.
- **`README.md`** — CI badge under the title, and `.github/` added to the repository-layout block (#3 established that block as maintained-as-truth, and this PR adds a directory to it).
- **`plans/2026-09-05_ci-setup.md`** — the plan, as the coding rules require.

## Decisions worth the reviewer's attention

**1. `black --check` is in the pipeline although the issue names only `ruff`.**
The issue's "ein einziges, schnelles Tool genügt" argument is about ruff replacing `flake8`/`isort` as a *linter*. `CLAUDE_CODING_RULES.md` separately requires black for formatting and points at this issue for the enforcement ("Python code needs to be formatted with `black`; linting with `ruff` (see issue #13)"). Both are one line each.

**2. `black --check src tests`, not `black --check .` — measured, not assumed.**
Two reasons:
- The notebook is not black-formatted: `black --check .` reports `01_notebooks/prediction.ipynb` would be reformatted. Reformatting the notebook that #5 curated is out of scope here.
- More importantly, `black --check .` is **non-deterministic across environments**. black silently skips `.ipynb` files unless the `black[jupyter]` extras are present — with a bare `black` install it prints "Skipping .ipynb files as Jupyter dependencies are not installed" and passes; once `tokenize-rt` is pulled in (transitively or otherwise) the same command fails on the notebook. Both behaviours were reproduced locally on the pinned `black==26.5.1`. Naming the directories removes that coin flip from CI.

`ruff check .` deliberately stays unscoped: ruff *does* check the notebook (confirmed with `ruff check . --show-files`, which lists `prediction.ipynb` among the 10 files) and it passes.

**3. Python 3.11.** `requirements.txt` states its pins "were resolved together on Python 3.11"; running CI on anything else would test a combination nobody validated.

**4. Action versions.** `checkout@v4` and `setup-python@v5` — current, known-good majors, rather than guessing at newer tags from a workflow that cannot be dry-run.

**5. No dataset step.** The suite runs on small synthetic DataFrames, so CI stays green without the ~1.6 GB Kaggle CSV. This is the one issue in the work plan whose acceptance criteria are fully verifiable in a cloud session.

## Model/Data-Leakage-Check (falls Notebook/Modell/Features betroffen)
- [x] Beeinflusst dieser PR Trainingsdaten, Features oder das Modell? — **Nein.** No file under `src/`, `tests/` or `01_notebooks/` is touched. The diff is one new workflow file, one new plan file and two additions to the README.
- [x] Falls ja: alte vs. neue Metriken (AUC, KS, Gini) im PR angegeben? — not applicable, no metric can change.
- [x] Keine neuen Features verwendet, die erst nach Kreditvergabe/Ausfall bekannt sind — no feature is added or removed.
- [x] Ein auffällig hoher/niedriger Metrikwert wurde erklärt, nicht nur berichtet? — not applicable, no metric is reported.

## How to test / Verification

The three CI commands were run locally on the pinned versions (Python 3.11.15, `pandas==3.0.5`, `ruff==0.16.5`, `black==26.5.1`, `pytest==9.1.1`) before the workflow was pushed:

- `ruff check .` — All checks passed (10 files, notebook included).
- `black --check src tests` — 9 files unchanged.
- `pytest tests/` — 20 passed.
- `.github/workflows/ci.yml` parses as valid YAML.

**Acceptance criterion 2 ("Workflow läuft bei einem Test-Push tatsächlich grün durch") is verified by this PR's own check run** — the `pull_request` trigger is unfiltered, so opening this PR is the test push. The reviewer should confirm the run is green before merging.

## Checklist
- [x] Notebook läuft sauber von oben nach unten durch (not touched by this PR; the standing limitation about the real dataset is unchanged and recorded in HANDOVER.md)
- [x] Tests laufen durch (`pytest tests/`) — 20 passed
- [x] README ggf. aktualisiert und weiterhin konsistent mit dem tatsächlichen Repo-Inhalt (badge added; `.github/` added to the layout block, listing both `pull_request_template.md` and the new workflow)
- [x] Keine Secrets/Zugangsdaten committet — the workflow needs none; it uses no `secrets` context

## Note for the reviewer

With this merged, issues #2-#13 are all done and the relay is complete. The remaining open items for the user are recorded in `HANDOVER.md` — chiefly the local "Restart & Run All" on the real dataset that #2, #3 and #5 are waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUYV7fQBiXXKLzuT1rJ6Hz

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUYV7fQBiXXKLzuT1rJ6Hz)_